### PR TITLE
fix(transaction-detail): konsistensi mapping gambar item + fallback aman saat load gagal

### DIFF
--- a/src/app/(navbar_layout)/transaction/[transactionId]/page.tsx
+++ b/src/app/(navbar_layout)/transaction/[transactionId]/page.tsx
@@ -323,7 +323,11 @@ const TransactionDetailPage: React.FC = () => {
                       width={48}
                       height={48}
                       className="w-full h-full object-cover"
-                      unoptimized
+                      unoptimized={false}
+                      onError={(e) => {
+                        const target = e.currentTarget as HTMLImageElement;
+                        if (!target.src.endsWith('/default-image.jpg')) target.src = '/default-image.jpg';
+                      }}
                     />
                   </div>
                   <div className="flex-1 min-w-0">

--- a/src/services/api/orders/index.ts
+++ b/src/services/api/orders/index.ts
@@ -22,6 +22,10 @@ export interface OrderListItemDto {
     price_per_item: number;
     total_price: number;
     created_at: string;
+    img?: string;
+    image?: string;
+    product_image?: string;
+    variant_image?: string;
   }>;
 }
 
@@ -114,7 +118,7 @@ const mapOrderItems = (
     variantName: item.variant_product,
     quantity: item.quantity,
     price: item.price_per_item,
-    image: "/default-image.jpg",
+    image: item.img || item.image || item.variant_image || item.product_image || "/default-image.jpg",
   }));
 
 export const mapOrderSummaryToTransaction = (


### PR DESCRIPTION
## Ringkasan
PR ini memperbaiki kasus di halaman detail transaksi ketika sebagian gambar item pesanan tidak tampil padahal data gambar tersedia di backend.

## Masalah Sebelumnya
- Mapping item transaksi di frontend masih mengisi `image` secara hardcoded ke `"/default-image.jpg"`.
- Akibatnya, URL gambar asli dari API tidak terbaca dan item tertentu selalu tampil placeholder.
- Jika URL gambar bermasalah, belum ada fallback runtime yang konsisten pada render.

## Perubahan Utama

### 1) Perbaikan mapping image dari response API order
File:
- `src/services/api/orders/index.ts`

Perubahan:
- Menambahkan dukungan field image pada DTO item order:
- `img?`
- `image?`
- `product_image?`
- `variant_image?`
- Update `mapOrderItems()` agar `image` dipilih berlapis:
1. `item.img`
2. `item.image`
3. `item.variant_image`
4. `item.product_image`
5. `"/default-image.jpg"`

### 2) Fallback runtime saat render image gagal
File:
- `src/app/(navbar_layout)/transaction/[transactionId]/page.tsx`

Perubahan:
- Tetap menggunakan `next/image`.
- Menambahkan `onError` fallback ke `"/default-image.jpg"` agar tidak blank saat URL gagal load.

## Dampak
- Gambar item transaksi lebih konsisten tampil jika URL tersedia.
- Jika URL rusak/tidak bisa diakses, UI tetap aman dengan fallback placeholder.
- Perubahan scope sempit: hanya flow detail transaksi + mapper order.

## Testing Checklist
- [ ] Buka detail transaksi yang sebelumnya ada item tanpa gambar.
- [ ] Verifikasi item dengan data gambar valid tampil normal.
- [ ] Verifikasi item dengan URL gambar invalid otomatis fallback ke default image.
- [ ] Pastikan tidak ada error runtime pada page transaksi.
- [ ] Cek transaksi lain untuk memastikan tidak ada regresi.

## Branch & Commit
- Branch: `staging-fix-image-fallback-consistency`
- Commit: `011fb65`